### PR TITLE
keycloak: updated template to use service name keycloak.local

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -43,7 +43,7 @@ Overriding of environment variables in the `docker-compose.yml` can be done via 
 Authentication by default is setup to use Keycloak. To use Keycloak, add an entry to your hosts file to resolve the Keycloak URL to your local machine. Add the following line to your system's `hosts` file:
 
 ```shell
-keycloak 127.0.0.1
+keycloak.local 127.0.0.1
 ```
 
 ### Connecting To Containers From Host

--- a/.devcontainer/devserver_config/oidc/conf.json
+++ b/.devcontainer/devserver_config/oidc/conf.json
@@ -4,7 +4,7 @@
     },
     "clients": {
         "iqgeo-oidc": {
-            "issuer": "http://keycloak:8080/realms/iqgeo",
+            "issuer": "http://keycloak.local:8080/realms/iqgeo",
             "client_id": "iqgeo-oidc",
             "client_secret": "qpyu1mCm8zvvKTXRnKxwap1A6xMChuY6",
             "redirect_uris": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,7 +31,7 @@ services:
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:memcached}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-memcached:11211}
-            KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak}:${KEYCLOAK_PORT:-8080}
+            KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8080}
             MYW_EXT_BASE_URL: http://${EXTERNAL_IP:-localhost}:${APP_PORT:-80} # for access from other devices (e.g. iPad running anywhere)
             MYW_BUILD_BASE_URL: http://iqgeo # address internal to docker network, to run server, js and gui tests
             MYW_WEBDRIVER_URL: http://selenium-chrome:4444 # run UI tests in selenium container
@@ -68,7 +68,7 @@ services:
         restart: always
         command: start-dev --import-realm
         environment:
-            KC_HOSTNAME: keycloak
+            KC_HOSTNAME: keycloak.local
             KC_HOSTNAME_PORT: ${KEYCLOAK_PORT:-8080}
             KC_HTTP_PORT: ${KEYCLOAK_PORT:-8080}
             KEYCLOAK_ADMIN: admin
@@ -79,6 +79,10 @@ services:
         ports:
             - ${KC_HTTPS_PORT:-8443}:${KC_HTTPS_PORT:-8443}
             - ${KEYCLOAK_PORT:-8080}:${KEYCLOAK_PORT:-8080}
+        networks:
+            default:
+                aliases:
+                    - keycloak.local
 
     memcached:
         container_name: memcached_${PROJ_PREFIX:-myproj}

--- a/.devcontainer/entrypoint.d/270_adjust_oidc_conf.sh
+++ b/.devcontainer/entrypoint.d/270_adjust_oidc_conf.sh
@@ -3,4 +3,4 @@
 # replace references to the application base URL in the oidc configuration file
 sed -i "s|{myw_ext_base_url}|${MYW_EXT_BASE_URL}|g" /opt/iqgeo/config/oidc/conf.json
 # replace references to the keycloak URL in the oidc configuration file
-sed -i "s|http://keycloak:8080|${KEYCLOAK_URL}|g" /opt/iqgeo/config/oidc/conf.json
+sed -i "s|http://keycloak.local:8080|${KEYCLOAK_URL}|g" /opt/iqgeo/config/oidc/conf.json

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use this template when creating a new repository, follow these steps:
 1. Update other files for your project/product/module (see sections below for guidance).
 1. Test the changes and make required adjustments by executing the dev environment
     - The dev environment is configured to use Keycloak for authentication. This requires you to add an entry to your hosts file to resolve the Keycloak URL to your local machine. Add the following line to your system's `hosts` file:
-      `127.0.0.1    keycloak`
+      `127.0.0.1    keycloak.local`
     - execute the dev environment by running: `docker compose -f ".devcontainer/docker-compose.yml" up -d --build `.
     - add any necessary entrypoints to `.devcontainer/entrypoint.d` and `deployment/entrypoint.d` for your modules or the product modules
 1. Commit and push your changes to the new repository.


### PR DESCRIPTION
It was found that when using anywhere, a redirect in a webview to domain 'keycloak' was causing an error to be thrown. Changing the domain to 'keycloak.local' fixes the issue.