### PR TITLE
devcontainer: added remote host configurations

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,14 +30,6 @@ https://harbor.delivery.iqgeo.cloud
     -   .vscode
     -   my_module
 
-# Starting a Development Container
-
-The **Visual Studio Code Remote - Containers** extension lets you use a Docker container as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set. The development container for Network Manager Comms contains Python, NodeJS, IQGeo Platform, and other tools and libraries to facilitate the development of the app.
-
-### Overriding ENV variables
-
-Overriding of environment variables in the `docker-compose.yml` can be done via `.env` file in this folder. Copy the `.env.example` file to `.env` and modify the values as described in its comments.
-
 ### Authentication
 
 Authentication by default is setup to use Keycloak. To use Keycloak, add an entry to your hosts file to resolve the Keycloak URL to your local machine. Add the following line to your system's `hosts` file:
@@ -45,6 +37,16 @@ Authentication by default is setup to use Keycloak. To use Keycloak, add an entr
 ```shell
 keycloak.local 127.0.0.1
 ```
+
+# Starting a Development Container (Local docker)
+
+Note: This section assumes Docker is running locally on your machine. For running development containers on a Development Server, please follow the [remote host README](remote_host/README.md)
+
+The **Visual Studio Code Remote - Containers** extension lets you use a Docker container as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set. The development container for Network Manager Comms contains Python, NodeJS, IQGeo Platform, and other tools and libraries to facilitate the development of the app.
+
+### Overriding ENV variables
+
+Overriding of environment variables in the `docker-compose.yml` can be done via `.env` file in this folder. Copy the `.env.example` file to `.env` and modify the values as described in its comments.
 
 ### Connecting To Containers From Host
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,5 @@
     },
     "remoteUser": "iqgeo",
     "containerUser": "www-data",
-    "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules"
+    "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules && myw_product watch applications_dev --debug"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,9 +11,23 @@ services:
         volumes:
             - pgdata:/var/lib/postgresql/data
 
-    iqgeo_myproj_devserver:
+    iqgeo:
+        extends: iqgeo-common
         container_name: iqgeo_${PROJ_PREFIX:-myproj}
+        profiles: [ 'iqgeo' ]
+        environment:
+            IQGEO_HOST: ${IQGEO_HOST:-localhost:${APP_PORT:-80}}
+            MYW_EXT_BASE_URL: http://${IQGEO_HOST:-localhost:${APP_PORT:-80}} # for access from other devices (e.g. iPad running anywhere)
+        depends_on:
+            - postgis
+            - keycloak
+            - memcached
+
+    iqgeo-common:
+        # this service definition is necessary to allow inheritance in the remote_host dev container, which cannot inherit the depends_on entry
+        container_name: iqgeo-common_${PROJ_PREFIX:-myproj}
         restart: always
+        profiles: [ 'definition-only' ]
         build:
             context: ./
             dockerfile: dockerfile
@@ -42,17 +56,19 @@ services:
             # START CUSTOM SECTION
             # END CUSTOM SECTION
         ports:
-            - ${APP_PORT:-80}:80
+            - ${APP_PORT:-80}:8080
         volumes:
             # add data folder to share data between host and container
             - ../data:/opt/iqgeo/platform/WebApps/myworldapp/modules/data:delegated
             # Map host directories and files into the container individually, to allow container to be created without losing platform directories
             - ../.vscode:/opt/iqgeo/platform/WebApps/myworldapp/modules/.vscode:delegated
             - ../.devcontainer:/opt/iqgeo/platform/WebApps/myworldapp/modules/.devcontainer:delegated
+            - ../deployment:/opt/iqgeo/platform/WebApps/myworldapp/modules/deployment:delegated
             - ../.git:/opt/iqgeo/platform/WebApps/myworldapp/modules/.git:delegated
             - ../.github:/opt/iqgeo/platform/WebApps/myworldapp/modules/.github:delegated
             - ../.prettierrc:/opt/iqgeo/platform/WebApps/myworldapp/modules/.prettierrc:delegated
             - ../.gitignore:/opt/iqgeo/platform/WebApps/myworldapp/modules/.gitignore:delegated
+            - ../.iqgeorc.jsonc:/opt/iqgeo/platform/WebApps/myworldapp/modules/.iqgeorc.jsonc:delegated
             - ../README.md:/opt/iqgeo/platform/WebApps/myworldapp/modules/README.md:delegated
 
             - js_bundles:/opt/iqgeo/platform/WebApps/myworldapp/public/bundles # to keep builds when container is recreated
@@ -61,9 +77,6 @@ services:
             # START SECTION - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
             - ../custom:/opt/iqgeo/platform/WebApps/myworldapp/modules/custom:delegated
             # END SECTION
-        depends_on:
-            - postgis
-            - keycloak
 
     keycloak:
         container_name: keycloak_${PROJ_PREFIX:-myproj}

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -14,7 +14,6 @@ FROM ${CONTAINER_REGISTRY}platform-devenv:7.1
 
 USER root
 
-# set iqgeo user ownership of volumes
 RUN mkdir -p ${MYWORLD_DATA_HOME}/tests
 
 # START SECTION optional dependencies (dev) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
@@ -63,5 +62,5 @@ USER www-data
 # configuration
 # paths for tools from modules
 # aditional environment variables
-# START CUSTOM SECTION - iqgeo user
+# START CUSTOM SECTION - www-data user
 # END CUSTOM SECTION

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -14,8 +14,8 @@ FROM ${CONTAINER_REGISTRY}platform-devenv:7.1
 
 USER root
 
+# set iqgeo user ownership of volumes
 RUN mkdir -p ${MYWORLD_DATA_HOME}/tests
-RUN chown iqgeo:iqgeo ${MYWORLD_DATA_HOME}/tests
 
 # START SECTION optional dependencies (dev) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 RUN apt-get update && \
@@ -29,28 +29,36 @@ RUN pip install cryptojwt
 COPY --link --from=comms / ${MODULES}/
 # END SECTION
 
+
 # START CUSTOM SECTION - root user
 # END CUSTOM SECTION
 
-# Give iqgeo user ownership of the modules
-RUN chown -R iqgeo:iqgeo ${MODULES}
-
-USER iqgeo
-
+# # fetch additional python dependencies
+RUN myw_product fetch pip_packages --include memcached oidc
+# ensure pip dependencies are readable by Apache(www-data) and iqgeo
+RUN chown -R www-data:www-data ${MYWORLD_HOME}/Externals && \
+    chmod -R g+w ${MYWORLD_HOME}/Externals
 
 # Build additional node_modules
 RUN myw_product fetch node_modules
-
-# fetch additional python dependencies
-RUN myw_product fetch pip_packages --include memcached oidc
+RUN chown -R www-data:www-data ${MODULES}
+RUN chmod -R g+w ${MODULES}
 
 RUN myw_product build core_dev --debug
+RUN chown -R www-data:www-data ${WEBAPPS}/myworldapp/public
+RUN chmod -R g+w ${WEBAPPS}/myworldapp/public
 
 
 # add additional entrypoint scripts 
-COPY --chown=iqgeo:iqgeo entrypoint.d/* /entrypoint.d/
+COPY --chown=www-data:www-data entrypoint.d/* /entrypoint.d/
 
-COPY --chown=iqgeo:iqgeo devserver_config/ /opt/iqgeo/config/
+COPY --chown=www-data:www-data devserver_config/ /opt/iqgeo/config/
+
+# ensure entrypoint files are executable
+RUN chmod +x entrypoint.d/*
+
+# entrypoints should run as www-data and not iqgeo otherwise the UID on the files created in entrypoints won't match the UID mapping done in the dev container
+USER www-data 
 
 # configuration
 # paths for tools from modules

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -10,7 +10,7 @@ FROM ${CONTAINER_REGISTRY}comms:3.1 as comms
 # END SECTION
 
 
-FROM ${CONTAINER_REGISTRY}platform-devenv:7.1
+FROM ${CONTAINER_REGISTRY}platform-devenv-2:7.1
 
 USER root
 

--- a/.devcontainer/remote_host/README.md
+++ b/.devcontainer/remote_host/README.md
@@ -1,0 +1,49 @@
+# Remote dev containers
+
+This folder contains the definitions and instructions to run dev environments hosted on a Development server.
+
+## Configure and Start shared Service Containers
+
+Note: This step need only be done once as all developers will make user of the same services. If the services are
+running on a separate system then this step is unnecessary.
+
+From this folder execute:
+
+```shell
+docker compose -f docker-compose-shared.yml up -d
+```
+
+## Configure the IQGeo dev container
+
+The **Remote Development** extension pack for Visual Studio Code lets you use a Docker container as a full-featured development environment hosted on a remote server. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set.
+
+This section assumes you've authenticated to Harbor as per the parent readme and the repo you'll be working on has been cloned to your user's home on the development server.
+
+It also assumes you've performed the [keycloak configuration](../README.md#authentication)
+
+### Open Dev Container in VS Code
+
+Using the **Remote Explore** extension in VS Code, connect via SSH to the server using your credentials.
+You can then perform the following steps using VSCode as an editor.
+
+### Overriding ENV variables
+
+Overriding of environment variables in the `docker-compose.yml` can be done via `.env` file in this folder. Copy the `.env.example` file from the parent folder to `.env` and modify the values as described in its comments.
+
+In particular, each developer needs to be assigned to their own port on the server and have a unique project and container name this needs to be configured before
+starting any containers. Navigate to the directory and open the .env file for editing. It should look something like this
+
+```
+PROJ_PREFIX=_myname
+APP_PORT=8081
+```
+
+Edit the entries to give each developer unique values.
+
+### Open Dev Container in VS Code
+
+You can now run the VS Code command "dev containers: Reopen in Container". (This can be done by clicking the blue button on bottom left corner of the window and chosing that command from the list or by pressing Cmd/Ctrl+P and typing in the command)
+
+### Troubleshooting
+
+(to complete)

--- a/.devcontainer/remote_host/devcontainer.json
+++ b/.devcontainer/remote_host/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "IQGeo Project Template",
+    "name": "IQGeo Project Template (Remote)",
     "dockerComposeFile": "docker-compose.yml",
     "service": "iqgeo",
     "runServices": ["iqgeo"],
@@ -21,5 +21,7 @@
     },
     "remoteUser": "iqgeo",
     "containerUser": "www-data",
+    "updateRemoteUserUID": true,
+    "forwardPorts": [8080, "keycloak:8081"],
     "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules"
 }

--- a/.devcontainer/remote_host/devcontainer.json
+++ b/.devcontainer/remote_host/devcontainer.json
@@ -23,5 +23,5 @@
     "containerUser": "www-data",
     "updateRemoteUserUID": true,
     "forwardPorts": [8080, "keycloak:8081"],
-    "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules"
+    "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules && myw_product watch applications_dev --debug"
 }

--- a/.devcontainer/remote_host/docker-compose-shared.yml
+++ b/.devcontainer/remote_host/docker-compose-shared.yml
@@ -1,0 +1,56 @@
+services:
+    postgis:
+        extends:
+            file: ../docker-compose.yml
+            service: postgis
+        container_name: postgis
+        networks:
+            - iqgeo-network
+
+    keycloak:
+        extends:
+            file: ../docker-compose.yml
+            service: keycloak
+        container_name: keycloak
+        environment:
+            KC_HOSTNAME_PORT: ${KEYCLOAK_PORT:-8081}
+            KC_HTTP_PORT: ${KEYCLOAK_PORT:-8081}
+            IQGEO_DOMAIN: http://${IQGEO_HOST:-localhost:8080}
+        ports:
+            - ${KC_HTTPS_PORT:-8443}:${KC_HTTPS_PORT:-8443}
+            - ${KEYCLOAK_PORT:-8081}:${KEYCLOAK_PORT:-8081}
+        networks:
+            iqgeo-network:
+                aliases:
+                    - keycloak.local
+
+    memcached:
+        extends:
+            file: ../docker-compose.yml
+            service: memcached
+        container_name: memcached
+        networks:
+            - iqgeo-network
+
+    pgadmin:
+        extends:
+            file: ../docker-compose.yml
+            service: pgadmin
+        container_name: pgadmin
+        networks:
+            - iqgeo-network
+    # START CUSTOM SECTION
+    # END CUSTOM SECTION
+
+volumes:
+    pgdata:
+        name: ${PROJ_PREFIX:-myproj}_pgdata
+    pgadmin-data:
+        name: ${PROJ_PREFIX:-myproj}_pgadmin_data
+    # START CUSTOM SECTION
+    # END CUSTOM SECTION
+
+networks:
+    iqgeo-network:
+        name: ${NETWORK_NAME:-iqgeo-network}
+        external: false

--- a/.devcontainer/remote_host/docker-compose.yml
+++ b/.devcontainer/remote_host/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+    iqgeo:
+        extends:
+            file: ../docker-compose.yml
+            service: iqgeo-common
+        container_name: iqgeo_${PROJ_PREFIX:-myproj}
+        environment:
+            APACHE_ERROR_LOG: ""
+        networks:
+            - iqgeo-network
+            # START CUSTOM SECTION
+            # END CUSTOM SECTION
+
+
+volumes:
+    js_bundles:
+        name: ${PROJ_PREFIX:-myproj}_js_bundles
+    # START CUSTOM SECTION
+    # END CUSTOM SECTION
+
+networks:
+    iqgeo-network:
+        name: ${NETWORK_NAME:-iqgeo-network}
+        external: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *~
 .DS_Store
 .env
+#files from platform that should be ignored (show as changed because of www-data ownership)
+/__init__.py
+/jsconfig.json
 
 # START SECTION Product modules
 /comms

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -9,7 +9,7 @@ An example docker compose file to start the containers locally is also included
 
 ### Platform image
 
-Authenticate with harbor so docker can download the Platform image(s)
+Authenticate with harbor so docker can download the IQGeo image(s)
 
 ```shell
 docker login harbor.delivery.iqgeo.cloud


### PR DESCRIPTION
Changes to template to better support remote dev containers (hosted on development servers)

- added new folder `remote_host` to hold these new configurations 
-compose: split iqgeo service to allow inheritance
-adjust for apache port now being 8080 (this is to match the new platform-devenv image, which was changed for consistency and better support for port forwarding to local machines)
-adjust file permissions and UID mapping

corresponding PR in utils-docker-platform: https://github.com/IQGeo/utils-docker-platform/pull/272