### PR TITLE
devcontainer: Updated Keycloak default port definitions to 8081

### DIFF
--- a/.devcontainer/remote_host/docker-compose.yml
+++ b/.devcontainer/remote_host/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         container_name: iqgeo_${PROJ_PREFIX:-myproj}
         environment:
             APACHE_ERROR_LOG: ""
+            KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8081}
+            
         networks:
             - iqgeo-network
             # START CUSTOM SECTION


### PR DESCRIPTION
When connecting to a remote host through SSH, the Keycloak default port was set to 8081. To ensure this works without updating the .env file, the default port had to be updated for the iqgeo service too.