### PR TITLE
devcontainer: fix the default IQGeo url in the keycloak definition

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -90,7 +90,7 @@ services:
             KEYCLOAK_ADMIN: admin
             KEYCLOAK_ADMIN_PASSWORD: _mywWorld_
             KC_PROXY: edge
-            IQGEO_DOMAIN: http://${IQGEO_HOST:-localhost}
+            IQGEO_DOMAIN: http://${IQGEO_HOST:-localhost:${APP_PORT:-80}}
             IQGEO_CLIENT_SECRET: qpyu1mCm8zvvKTXRnKxwap1A6xMChuY6
         ports:
             - ${KC_HTTPS_PORT:-8443}:${KC_HTTPS_PORT:-8443}


### PR DESCRIPTION
by default keycloak was redirecting to http://localhost
even if a different port was configured