### PR TITLE
remote_host: set default IQGEO_HOST and updated README.md

### DIFF
--- a/.devcontainer/remote_host/README.md
+++ b/.devcontainer/remote_host/README.md
@@ -13,6 +13,8 @@ From this folder execute:
 docker compose -f docker-compose-shared.yml up -d
 ```
 
+If you override the default Keycloak port using the `KEYCLOAK_PORT` environment variable, update the `forwardPorts` in `devcontainer.json` to match the new port. By default, Keycloak runs on port 8081.
+
 ## Configure the IQGeo dev container
 
 The **Remote Development** extension pack for Visual Studio Code lets you use a Docker container as a full-featured development environment hosted on a remote server. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set.

--- a/.devcontainer/remote_host/docker-compose.yml
+++ b/.devcontainer/remote_host/docker-compose.yml
@@ -7,7 +7,9 @@ services:
         environment:
             APACHE_ERROR_LOG: ""
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8081}
-            
+            IQGEO_HOST: ${IQGEO_HOST:-localhost:8080}
+            MYW_EXT_BASE_URL: http://${IQGEO_HOST:-localhost:8080} # Default to localhost:8080 so correct redirect_uri is used for Keycloak when port forwarding
+
         networks:
             - iqgeo-network
             # START CUSTOM SECTION


### PR DESCRIPTION
Changes made
- Updated `remote_host/README.md` to give instruction to update the devcontainer.json if the keycloak port changes.
- Added default IQGEO_HOST to `remote_host/docker-compose.hml`. Without this setting, port forwarding does not work as the redirect sent to Keycloak uses port 80