### PR TITLE
remote-host: moved env values for dev container to devcontainer.json

### DIFF
--- a/.devcontainer/remote_host/devcontainer.json
+++ b/.devcontainer/remote_host/devcontainer.json
@@ -23,5 +23,9 @@
     "containerUser": "www-data",
     "updateRemoteUserUID": true,
     "forwardPorts": [8080, "keycloak:8081"],
+    "containerEnv": {
+        "IQGEO_HOST": "localhost:8080",
+        "MYW_EXT_BASE_URL": "http://localhost:8080"
+    },
     "postStartCommand": "git config --global --add safe.directory /opt/iqgeo/platform/WebApps/myworldapp/modules && myw_product fetch node_modules && myw_product watch applications_dev --debug"
 }

--- a/.devcontainer/remote_host/docker-compose.yml
+++ b/.devcontainer/remote_host/docker-compose.yml
@@ -7,8 +7,6 @@ services:
         environment:
             APACHE_ERROR_LOG: ""
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8081}
-            IQGEO_HOST: ${IQGEO_HOST:-localhost:8080}
-            MYW_EXT_BASE_URL: http://${IQGEO_HOST:-localhost:8080} # Default to localhost:8080 so correct redirect_uri is used for Keycloak when port forwarding
 
         networks:
             - iqgeo-network


### PR DESCRIPTION
A recommendation from Daniel Indigo.

Since we need IQGEO_HOST and MYW_EXT_BASE_URL to be set to `localhost:8080` when running using the dev container extension, we can add the values to the `devcontainer.json` to ensure they are not overwritten by the user of a .env when running from dev container extension.  