### PR TITLE
Enable development in containers started with docker compose.

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -7,10 +7,13 @@ COMPOSE_PROJECT_NAME=${PROJ_PREFIX}_dev
 
 #uncomment and adjust values to be able to run several projects on the same machine. The values below have an offset of 1 from default values. When changing it is recommended to change all with the same offset
 #APP_PORT=81
+#IQGEO_HOST=localhost:${APP_PORT}
 #POSTGIS_PORT=5433
 #KEYCLOAK_PORT=8081
 #KC_HTTPS_PORT=8443
 #PGADMIN_PORT=8091
+#UID=1000
+#GID=1000
 
 # START CUSTOM SECTION
 # END CUSTOM SECTION

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,8 @@ services:
             dockerfile: dockerfile
             args:
                 - CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-harbor.delivery.iqgeo.cloud/releases/}
+                - USER_UID=${UID:-1000}
+                - USER_GID=${GID:-1000}
         environment:
             DEBUG: 'true' # only for local testing. do not include in production or exposed environments!
             ALLOW_HTTP: 'YES' # only for local testing. do not include in production or exposed environments!        

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -24,6 +24,16 @@ RUN apt-get update && \
 
 RUN pip install cryptojwt
 
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG USER_NAME=iqgeo
+
+# Update the UID and GID of the user in the container
+# to match the users UID and GID on the host
+RUN groupmod -g $USER_GID $USER_NAME 
+RUN usermod -u $USER_UID -g $USER_GID $USER_NAME
+RUN chown -R $USER_UID:$USER_GID /home/$USER_NAME
+
 # START SECTION Copy the modules - beware this section is updated by the IQGeo project configuration tool
 COPY --link --from=comms / ${MODULES}/
 # END SECTION

--- a/.devcontainer/remote_host/devcontainer.json
+++ b/.devcontainer/remote_host/devcontainer.json
@@ -5,6 +5,10 @@
     "runServices": ["iqgeo"],
     "workspaceFolder": "/opt/iqgeo/platform/WebApps/myworldapp/modules",
     "shutdownAction": "stopCompose",
+    "containerEnv": {
+        "IQGEO_HOST": "localhost:8080",
+        "MYW_EXT_BASE_URL": "http://localhost:8080"
+    },
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
Implement uid/gid mapping as is done in a devcontainer to enable editing of files 
Update devcontainer.json to ensure parameters set for using in a regular docker container don't interfere with using a devcontainer. This is also useful for when the default port 8080 is in use on the local system