### PR TITLE
use `AS` keyword all-caps, not `as`

### DIFF
--- a/deployment/dockerfile.appserver
+++ b/deployment/dockerfile.appserver
@@ -1,6 +1,6 @@
 ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
 
-FROM iqgeo-myproj-build as iqgeo_builder
+FROM iqgeo-myproj-build AS iqgeo_builder
 
 # START SECTION optional dependencies (build) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 RUN apt-get update && \
@@ -38,7 +38,7 @@ COPY --chown=www-data:www-data --from=iqgeo_builder ${MODULES}/comms/ ${MODULES}
 # END CUSTOM SECTION
 
 
-# Copy in generated bundles 
+# Copy in generated bundles
 COPY --chown=www-data:www-data --from=iqgeo_builder ${WEBAPPS}/myworldapp/public ${WEBAPPS}/myworldapp/public/
 
 

--- a/deployment/dockerfile.tools
+++ b/deployment/dockerfile.tools
@@ -1,12 +1,12 @@
 ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
 
-FROM iqgeo-myproj-build as iqgeo_builder
+FROM iqgeo-myproj-build AS iqgeo_builder
 
 # START SECTION optional dependencies (build) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 
 # END SECTION
 
-FROM ${CONTAINER_REGISTRY}platform-tools:7.2 as tools_intermediate
+FROM ${CONTAINER_REGISTRY}platform-tools:7.2 AS tools_intermediate
 
 USER root
 


### PR DESCRIPTION
![Screenshot 2024-09-11 at 14 57 54](https://github.com/user-attachments/assets/f7230686-e88e-427b-9325-6d3b3bff9d76)

There are some complaints about syntax in some linting that is running. These changes address those warnings.