### PR TITLE
docker-compose: docker-compose: updated postgis image used to 12-3.5.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgis:
-        image: ghcr.io/iqgeo/utils-docker-postgis/postgis:12-3.4
+        image: ghcr.io/iqgeo/docker-postgis/postgis:12-3.5
         container_name: postgis_${PROJ_PREFIX:-myproj}
         restart: always
         environment:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgis:
-        image: ghcr.io/iqgeo/utils-docker-postgis/postgis:12-3.4
+        image: ghcr.io/iqgeo/docker-postgis/postgis:12-3.5
         container_name: postgis_${PROJ_PREFIX:-myproj}
         restart: always
         environment:


### PR DESCRIPTION
The location of the PostGIS image provided by IQGeo has changed. This PR updates the image location and bumps it to use the latest PostGIS 3.5 version for PostgreSQL 12.

Note: The previous image is still available and will work without issue.