### PR TITLE
remote_host: added forwardPort value for pgadmin in devcontainer.json

### DIFF
--- a/.devcontainer/remote_host/devcontainer.json
+++ b/.devcontainer/remote_host/devcontainer.json
@@ -22,7 +22,7 @@
     "remoteUser": "iqgeo",
     "containerUser": "www-data",
     "updateRemoteUserUID": true,
-    "forwardPorts": [8080, "keycloak:8081"],
+    "forwardPorts": [8080, "keycloak:8081", "pgadmin:80"],
     "containerEnv": {
         "IQGEO_HOST": "localhost:8080",
         "MYW_EXT_BASE_URL": "http://localhost:8080"


### PR DESCRIPTION
Updated the `devcontainer.json` in remote_host to allow developers to connect to `pgadmin` from their host machine. I think this makes since `pgadmin` is included in the shared services.

TODO:
Going to update the README.md found in the remote_host directory with instructions on accessing pgadmin.