### PR TITLE
bug/remove memcached from remote_host shared services

### DIFF
--- a/.devcontainer/remote_host/docker-compose-shared.yml
+++ b/.devcontainer/remote_host/docker-compose-shared.yml
@@ -24,14 +24,6 @@ services:
                 aliases:
                     - keycloak.local
 
-    memcached:
-        extends:
-            file: ../docker-compose.yml
-            service: memcached
-        container_name: memcached
-        networks:
-            - iqgeo-network
-
     redis:
         extends:
             file: ../docker-compose.yml


### PR DESCRIPTION
Missed removing memached from remote_hosts shared services.  

Should get this merged ASAP as it will cause issues trying to started the shared services from the remote host directory.