### PR TITLE
docker-compose: updated rq-dashboard with paramaterized name

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -128,7 +128,7 @@ services:
             - postgis
 
     rq-dashboard:
-        container_name: rq-dashboard
+        container_name: rq-dashboard_${PROJ_PREFIX:-myproj}
         image: cjlapao/rq-dashboard:latest
         restart: always
         ports:


### PR DESCRIPTION
Updated rq-dashboard name defined in the devcontainer docker-compose to use _${PROJ_PREFIX:-myproj} to prevent name conflicts.