### PR TITLE
docker-compose: fixed KEYCLOAK_HOST url in remote_hosts/docker-compose

### DIFF
--- a/.devcontainer/remote_host/docker-compose.yml
+++ b/.devcontainer/remote_host/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         container_name: iqgeo_${PROJ_PREFIX:-myproj}
         environment:
             APACHE_ERROR_LOG: ""
-            KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KC_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8081}
+            KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KEYCLOAK_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8081}
 
         networks:
             - iqgeo-network


### PR DESCRIPTION
Missed in a recent refactor to  ${KEYCLOAK_HOST}. Seemed to overlook the remote_hosts directory.