### PR TITLE
docker-compose: updated PostGIS to 15-3.5

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgis:
-        image: ghcr.io/iqgeo/docker-postgis/postgis:12-3.5
+        image: ghcr.io/iqgeo/docker-postgis/postgis:15-3.5
         container_name: postgis_${PROJ_PREFIX:-myproj}
         restart: always
         environment:
@@ -22,7 +22,7 @@ services:
             - postgis
             - keycloak
             - redis
-            
+
     iqgeo-common:
         # this service definition is necessary to allow inheritance in the remote_host dev container, which cannot inherit the depends_on entry
         container_name: iqgeo-common_${PROJ_PREFIX:-myproj}
@@ -60,7 +60,7 @@ services:
             # END CUSTOM SECTION
         ports:
             - ${APP_PORT:-80}:8080
-            
+
         volumes:
             # add data folder to share data between host and container
             - ../data:/opt/iqgeo/platform/WebApps/myworldapp/modules/data:delegated
@@ -142,7 +142,7 @@ services:
 
 volumes:
     pgdata:
-        name: ${PROJ_PREFIX:-myproj}_pgdata
+        name: ${PROJ_PREFIX:-myproj}_pgdata15
     pgadmin-data:
         name: ${PROJ_PREFIX:-myproj}_pgadmin_data
     js_bundles:

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -45,5 +45,5 @@
     // e.g. [".devcontainer/remote_host"]
     "exclude_file_paths": [],
 
-    "version": "0.5.0"
+    "version": "0.6.0"
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgis:
-        image: ghcr.io/iqgeo/docker-postgis/postgis:12-3.5
+        image: ghcr.io/iqgeo/docker-postgis/postgis:15-3.5
         container_name: postgis_${PROJ_PREFIX:-myproj}
         restart: always
         environment:
@@ -107,5 +107,6 @@ services:
 
 volumes:
     pgdata-example:
+        name: ${PROJ_PREFIX:-myproj}_pgdata-example15
         # START CUSTOM SECTION
         # END CUSTOM SECTION


### PR DESCRIPTION
Updates the postgis version to 15. 

The timing of this merge should coincide with an announcement. Should a team or developer choose to update their project to the latest version of the template, the version change will impact their development environments as their existing database was built and ran under v12.

The service will fail to start with the following error:

```
2024-11-27 16:31:18.726 UTC [1] FATAL:  database files are incompatible with server
2024-11-27 16:31:18.726 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 12, which is not compatible with this version 15.8 (Debian 15.8-1.pgdg110+1).
```