### PR TITLE
dockerfile: remove use of COPY --link when using --from

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 RUN pip install cryptojwt
 
 # START SECTION Copy the modules - beware this section is updated by the IQGeo project configuration tool
-COPY --link --from=comms / ${MODULES}/
+COPY --from=comms / ${MODULES}/
 # END SECTION
 
 

--- a/deployment/dockerfile.build
+++ b/deployment/dockerfile.build
@@ -8,7 +8,7 @@ FROM ${CONTAINER_REGISTRY}platform-build:7.2
 
 # START SECTION Copy the modules - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 COPY --link custom ${MODULES}/custom
-COPY --link --from=comms / ${MODULES}/
+COPY --from=comms / ${MODULES}/
 # END SECTION
 
 # START CUSTOM SECTION


### PR DESCRIPTION
would cause problems when using containerd image store.
To match change in https://github.com/IQGeo/utils-project-update/pull/15
