### PR TITLE
docker-compose: added rq-dashboard do depends_on so it starts when using dev container extension

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,7 +22,7 @@ services:
             - postgis
             - keycloak
             - redis
-            
+
     iqgeo-common:
         # this service definition is necessary to allow inheritance in the remote_host dev container, which cannot inherit the depends_on entry
         container_name: iqgeo-common_${PROJ_PREFIX:-myproj}
@@ -60,7 +60,7 @@ services:
             # END CUSTOM SECTION
         ports:
             - ${APP_PORT:-80}:8080
-            
+
         volumes:
             # add data folder to share data between host and container
             - ../data:/opt/iqgeo/platform/WebApps/myworldapp/modules/data:delegated
@@ -134,7 +134,7 @@ services:
         ports:
             - ${RQ_DASHBOARD_PORT:-9181}:9181
         environment:
-            RQ_DASHBOARD_REDIS_URL: ${RQ_REDIS_URL:-redis://:password@redis:6379}
+            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379}
         depends_on:
             - redis
     # START CUSTOM SECTION


### PR DESCRIPTION
The defined Redis environment variable for rq-dashboard was incorrect not consistent with other location in the docker-compose