### PR TITLE
ET-274: update container registry paths for new registry organisation

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,7 +32,7 @@ services:
             context: ./
             dockerfile: dockerfile
             args:
-                - CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-harbor.delivery.iqgeo.cloud/releases/}
+                - PRODUCT_REGISTRY=${PRODUCT_REGISTRY:-harbor.delivery.iqgeo.cloud/releases_}
         environment:
             DEBUG: 'true' # only for local testing. do not include in production or exposed environments!
             ALLOW_HTTP: 'YES' # only for local testing. do not include in production or exposed environments!

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -3,14 +3,14 @@
 # IQGeo Platform. It is based on the platform-devenv image and optionally
 # adds additional modules to the image. The modules are copied from the injector images
 #
-ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
+ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 
 # START SECTION Aliases for Injector images - beware this section is updated by the IQGeo project configuration tool
-FROM ${CONTAINER_REGISTRY}comms:3.2 AS comms
+FROM ${PRODUCT_REGISTRY}comms/comms:3.2 AS comms
 # END SECTION
 
 
-FROM ${CONTAINER_REGISTRY}platform-devenv-2:7.2
+FROM ${PRODUCT_REGISTRY}platform/platform-devenv-2:7.2
 
 USER root
 

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -45,5 +45,5 @@
     // e.g. [".devcontainer/remote_host"]
     "exclude_file_paths": [],
 
-    "version": "0.6.0"
+    "version": "0.7.0"
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             context: ./
             dockerfile: dockerfile.tools
             args:
-                - CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-harbor.delivery.iqgeo.cloud/releases/}
+                - PRODUCT_REGISTRY=${PRODUCT_REGISTRY:-harbor.delivery.iqgeo.cloud/releases_}
         image: iqgeo-myproj-tools:latest
         container_name: iqgeo_${PROJ_PREFIX:-myproj}_worker
         restart: always
@@ -44,7 +44,7 @@ services:
             context: ./
             dockerfile: dockerfile.appserver
             args:
-                - CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-harbor.delivery.iqgeo.cloud/releases/}
+                - PRODUCT_REGISTRY=${PRODUCT_REGISTRY:-harbor.delivery.iqgeo.cloud/releases_}
         image: iqgeo-myproj-appserver:latest
         container_name: iqgeo_${PROJ_PREFIX:-myproj}_appserver
         restart: always

--- a/deployment/dockerfile.appserver
+++ b/deployment/dockerfile.appserver
@@ -1,4 +1,4 @@
-ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
+ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 
 FROM iqgeo-myproj-build AS iqgeo_builder
 
@@ -16,7 +16,7 @@ RUN rm -rf ${MODULES}/*/node_modules \
     && rm -rf ${MODULES}/*/native
 
 ############################################## project appserver image
-FROM ${CONTAINER_REGISTRY}platform-appserver:7.2
+FROM ${PRODUCT_REGISTRY}platform/platform-appserver:7.2
 
 USER root
 

--- a/deployment/dockerfile.build
+++ b/deployment/dockerfile.build
@@ -1,10 +1,10 @@
-ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
+ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 # START SECTION Aliases for Injector images
-FROM ${CONTAINER_REGISTRY}comms:3.2 AS comms
+FROM ${PRODUCT_REGISTRY}comms/comms:3.2 AS comms
 # END SECTION
 
 # Create container for building the project
-FROM ${CONTAINER_REGISTRY}platform-build:7.2
+FROM ${PRODUCT_REGISTRY}platform/platform-build:7.2
 
 # START SECTION Copy the modules - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 COPY --link custom ${MODULES}/custom

--- a/deployment/dockerfile.tools
+++ b/deployment/dockerfile.tools
@@ -1,4 +1,4 @@
-ARG CONTAINER_REGISTRY=harbor.delivery.iqgeo.cloud/releases/
+ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 
 FROM iqgeo-myproj-build AS iqgeo_builder
 
@@ -6,7 +6,7 @@ FROM iqgeo-myproj-build AS iqgeo_builder
 
 # END SECTION
 
-FROM ${CONTAINER_REGISTRY}platform-tools:7.2 AS tools_intermediate
+FROM ${PRODUCT_REGISTRY}platform/platform-tools:7.2 AS tools_intermediate
 
 USER root
 


### PR DESCRIPTION
Updates container registry paths for new registry organisation.
introduces PRODUCT_REGISTRY env variable, replacing CONTAINER_REGISTRY, so paths don't become incorrect if that variable is being set to point to a customer specific folder in the registry.

Note: I believe this is complete but it is still in draft because it requires the images to be in the new locations so it can be tested appropriately - which needs to be done before merging