### PR TITLE
PLAT-11234: add tsconfig

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -74,6 +74,7 @@ services:
             - ../.gitignore:/opt/iqgeo/platform/WebApps/myworldapp/modules/.gitignore:delegated
             - ../.iqgeorc.jsonc:/opt/iqgeo/platform/WebApps/myworldapp/modules/.iqgeorc.jsonc:delegated
             - ../README.md:/opt/iqgeo/platform/WebApps/myworldapp/modules/README.md:delegated
+            - ../tsconfig.json:/opt/iqgeo/platform/WebApps/myworldapp/modules/tsconfig.json:delegated
 
             - js_bundles:/opt/iqgeo/platform/WebApps/myworldapp/public/bundles # to keep builds when container is recreated
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ node_modules
 #files from platform that should be ignored (show as changed because of www-data ownership)
 /__init__.py
 /jsconfig.json
-/tsconfig.json
 /tsconfig.core.json
 
 # START SECTION Product modules

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -45,5 +45,5 @@
     // e.g. [".devcontainer/remote_host"]
     "exclude_file_paths": [],
 
-    "version": "0.6.0"
+    "version": "0.7.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
             "myWorld-native-services": ["../core/native/native-client.js"],
             "modules/dev_tools/*": ["./dev_tools/public/*"],
             "modules/vector_tile_styles/*": ["./vector_tile_styles/public/*"],
-            "images/*": ["../core/client/images/*"]
+            "images/*": ["../core/client/images/*"],
+            "config-shared": ["../core/config/shared"],
+            "config-settings": ["../core/config/config-settings.js"]
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.core.json",
+    "compilerOptions": {
+        "paths": {
+            "myWorld-base": ["../core/client/myWorld-client-namespace.js"],
+            "myWorld-client": ["../core/client/myWorld-client-namespace.js"],
+            "myWorld-client/react": ["../core/client/uiComponents/react"],
+            "myWorld-native-services": ["../core/native/native-client.js"],
+            "modules/dev_tools/*": ["./dev_tools/public/*"],
+            "modules/vector_tile_styles/*": ["./vector_tile_styles/public/*"],
+            "images/*": ["../core/client/images/*"]
+        }
+    }
+}


### PR DESCRIPTION
There's a mismatch between how Webpack and TypeScript resolve module paths. Namely, `modules/<module>/*` is mapped to `./<module>/public/*`. This can't be fixed by defining static paths in [core](https://github.com/IQGeo/myworld-product-core/blob/master/WebApps/myworldapp/modules/tsconfig.core.json), because TypeScript only allows one wildcard in a path, so we can't do `./*/public/*`.

This PR adds a tsconfig.json file that the project-update tool can dynamically populate with path mappings for each module defined in .iqgeorc.jsonc.

https://github.com/IQGeo/utils-project-update/pull/18

## Additional Notes

I went through each path defined in tsconfig.core.json and tried them in the comms repo, removing any that didn't work. Some only worked in certain directories, so there's a chance I've removed some that should remain.