### PR TITLE
Align files with initial state of .iqgeorc.jsonc

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -6,7 +6,7 @@
 ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 
 # START SECTION Aliases for Injector images - beware this section is updated by the IQGeo project configuration tool
-FROM ${PRODUCT_REGISTRY}comms/comms:3.2 AS comms
+FROM ${PRODUCT_REGISTRY}comms/comms:3.3 AS comms
 # END SECTION
 
 

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -17,9 +17,7 @@ USER root
 RUN mkdir -p ${MYWORLD_DATA_HOME}/tests
 
 # START SECTION optional dependencies (dev) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
-RUN apt-get update && \
-    apt-get install -y libmemcached-dev libmemcached11 \
-    && apt-get autoremove && apt-get clean
+
 # END SECTION
 
 RUN pip install cryptojwt

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -37,7 +37,7 @@
         },
         {
             "name": "comms",
-            "version": "3.2"
+            "version": "3.3"
         }
     ],
 

--- a/deployment/dockerfile.appserver
+++ b/deployment/dockerfile.appserver
@@ -3,12 +3,10 @@ ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 FROM iqgeo-myproj-build AS iqgeo_builder
 
 # START SECTION optional dependencies (build) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
-RUN apt-get update && \
-    apt-get install -y libmemcached-dev \
-    && apt-get autoremove && apt-get clean
+
 # END SECTION
 
-RUN myw_product fetch pip_packages --include memcached redis oidc
+RUN myw_product fetch pip_packages --include redis oidc
 
 # remove unneeded files for appserver
 RUN rm -rf ${MODULES}/*/node_modules \
@@ -21,9 +19,7 @@ FROM ${PRODUCT_REGISTRY}platform/platform-appserver:7.2
 USER root
 
 # START SECTION optional dependencies (runtime) - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
-RUN apt-get update && \
-    apt-get install -y libmemcached11 \
-    && apt-get autoremove && apt-get clean
+
 # END SECTION
 
 # Copy pip packages including modules' pip dependencies

--- a/deployment/dockerfile.build
+++ b/deployment/dockerfile.build
@@ -1,6 +1,6 @@
 ARG PRODUCT_REGISTRY=harbor.delivery.iqgeo.cloud/releases_
 # START SECTION Aliases for Injector images
-FROM ${PRODUCT_REGISTRY}comms/comms:3.2 AS comms
+FROM ${PRODUCT_REGISTRY}comms/comms:3.3 AS comms
 # END SECTION
 
 # Create container for building the project

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
             "modules/vector_tile_styles/*": ["./vector_tile_styles/public/*"],
             "images/*": ["../core/client/images/*"],
             "config-shared": ["../core/config/shared"],
-            "config-settings": ["../core/config/config-settings.js"]
+            "config-settings": ["../core/config/config-settings.js"],
+            "modules/custom/*": ["./custom/public/*"],
+            "modules/comms/*": ["./comms/public/*"]
         }
     }
 }


### PR DESCRIPTION
Someone that creates a new project/repo from the template, and just runs the update will get some file changes that wouldn't be expected, as they're not from any changes to the .iqgeorc.jsonc. They're just files that were left out of sync.
This aligns those files