### PR TITLE
devcontainer: remove volume to keep js bundles

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -76,8 +76,6 @@ services:
             - ../README.md:/opt/iqgeo/platform/WebApps/myworldapp/modules/README.md:delegated
             - ../tsconfig.json:/opt/iqgeo/platform/WebApps/myworldapp/modules/tsconfig.json:delegated
 
-            - js_bundles:/opt/iqgeo/platform/WebApps/myworldapp/public/bundles # to keep builds when container is recreated
-
             # Map host module directories to the container
             # START SECTION - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
             - ../custom:/opt/iqgeo/platform/WebApps/myworldapp/modules/custom:delegated


### PR DESCRIPTION
Seems to cause issues to some teams when things are touched by a different user (build triggered by task) and are then hard to fix because the volume keeps the permissions on those files
I don't think this is  needed anymore since we always start a build on startup.
