### PR TITLE
tsconfig: add missing myWorld path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.core.json",
     "compilerOptions": {
         "paths": {
+            "myWorld/*": ["../core/client/*"],
             "myWorld-base": ["../core/client/myWorld-client-namespace.js"],
             "myWorld-client": ["../core/client/myWorld-client-namespace.js"],
             "myWorld-client/react": ["../core/client/uiComponents/react"],


### PR DESCRIPTION
Modules can import from `myWorld/*`, but TS complains, because the path mapping isn't include `tsconfig.json`.