### PR TITLE
.devcontainer: rq-dashboard changed to trigger on container start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "IQGeo Project Template",
     "dockerComposeFile": "docker-compose.yml",
     "service": "iqgeo",
-    "runServices": ["iqgeo"],
+    "runServices": ["iqgeo", "rq-dashboard"],
     "workspaceFolder": "/opt/iqgeo/platform/WebApps/myworldapp/modules",
     "shutdownAction": "stopCompose",
     "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,7 +22,6 @@ services:
             - postgis
             - keycloak
             - redis
-            - rq-dashboard
 
     iqgeo-common:
         # this service definition is necessary to allow inheritance in the remote_host dev container, which cannot inherit the depends_on entry
@@ -134,7 +133,7 @@ services:
         ports:
             - ${RQ_DASHBOARD_PORT:-9181}:9181
         environment:
-            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
+            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379}
         depends_on:
             - redis
     # START CUSTOM SECTION

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,6 +22,7 @@ services:
             - postgis
             - keycloak
             - redis
+            - rq-dashboard
 
     iqgeo-common:
         # this service definition is necessary to allow inheritance in the remote_host dev container, which cannot inherit the depends_on entry
@@ -133,7 +134,7 @@ services:
         ports:
             - ${RQ_DASHBOARD_PORT:-9181}:9181
         environment:
-            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379}
+            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
         depends_on:
             - redis
     # START CUSTOM SECTION


### PR DESCRIPTION
The dev container, when run through the extension, will only start containers defined in the depends_on section or specified via runServices in devcontainer.json. The pattern we've selected is to define these services in depends_on.

Changes:
- Added rq-dashboard to the depends_on section of the Compose YAML.
- Fixed the default Redis connection string set for the rq-dashboard service.