### PR TITLE
.devcontainer: RQ dashboard URL consistent with LRT URL

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -133,7 +133,7 @@ services:
         ports:
             - ${RQ_DASHBOARD_PORT:-9181}:9181
         environment:
-            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379}
+            RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
         depends_on:
             - redis
     # START CUSTOM SECTION


### PR DESCRIPTION
A bit higher, LRT is configured to use db 1 by default: https://github.com/IQGeo/utils-project-template/blob/d7daabc503ea9ee622aaa4ae96874a73f31d3d37/.devcontainer/docker-compose.yml#L50

If RQ dashboard is not configured to look at the same redis db, you cannot see your tasks and workers.