### PR TITLE
PLAT-11713: docker: update ROPC_ENABLE variable to "true" to match ut…

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -56,7 +56,7 @@ services:
             MYW_BUILD_BASE_URL: http://iqgeo # address internal to docker network, to run server, js and gui tests
             MYW_WEBDRIVER_URL: http://selenium-chrome:4444 # run UI tests in selenium container
             APACHE_ERROR_LOG: /var/log/apache2/error.log
-            ROPC_ENABLE: ${ROPC_ENABLE:-1}
+            ROPC_ENABLE: ${ROPC_ENABLE:-true}
             # START CUSTOM SECTION
             # END CUSTOM SECTION
         ports:


### PR DESCRIPTION
To enable ROPC, the docker image is looking for the variable to be set to "true". 
This PR updates the default env variable to match what the utils-docker-platform is looking for 
in order to enable ROPC.