### PR TITLE
tsconfig: add merged internal path aliases for myWorld-client/react

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
             "myWorld/*": ["../core/client/*"],
             "myWorld-base": ["../core/client/myWorld-client-namespace.js"],
             "myWorld-client": ["../core/client/myWorld-client-namespace.js"],
-            "myWorld-client/react": ["../core/client/uiComponents/react"],
             "myWorld-native-services": ["../core/native/native-client.js"],
             "modules/dev_tools/*": ["./dev_tools/public/*"],
             "modules/vector_tile_styles/*": ["./vector_tile_styles/public/*"],
@@ -13,7 +12,10 @@
             "config-shared": ["../core/config/shared"],
             "config-settings": ["../core/config/config-settings.js"],
             "modules/custom/*": ["./custom/public/*"],
-            "modules/comms/*": ["./comms/public/*"]
+            "modules/comms/*": ["./comms/public/*"],
+            // These are merged into `myWorld-client/react` in `dev_tools/typings/ambient.d.ts`
+            "@internal/hooks": ["../core/client/hooks"],
+            "@internal/uiComponents/react": ["../core/client/uiComponents/react"]
         }
     }
 }


### PR DESCRIPTION
This PR adds the `tsconfig.core.json` changes from https://github.com/IQGeo/myworld-product-core/pull/2060.

The `myWorld-client/react` import alias is comprised of two separately exported modules from core: `core/client/hooks` and `core/client/uiComponents/react`. `compilerOptions.paths` doesn't support merging two separate modules, so an ambient module declaration was added instead. This declaration references `@internal/hooks` and `@internal/uiComponents/react`, both of which need to be aliased in the consuming project.