### PR TITLE
story/PLAT-11781: docker: added functionality for developers to set apache ports.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             dockerfile: dockerfile
             args:
                 - PRODUCT_REGISTRY=${PRODUCT_REGISTRY:-harbor.delivery.iqgeo.cloud/releases_}
+                - APACHE_PORT_OVERRIDE=${APACHE_PORT_OVERRIDE:-8080}
         environment:
             DEBUG: 'true' # only for local testing. do not include in production or exposed environments!
             ALLOW_HTTP: 'YES' # only for local testing. do not include in production or exposed environments!
@@ -60,7 +61,7 @@ services:
             # START CUSTOM SECTION
             # END CUSTOM SECTION
         ports:
-            - ${APP_PORT:-80}:8080
+            - ${APP_PORT:-80}:${APACHE_PORT_OVERRIDE:-8080}
 
         volumes:
             # add data folder to share data between host and container

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -28,6 +28,9 @@ COPY --from=comms / ${MODULES}/
 
 
 # START CUSTOM SECTION - root user
+ARG APACHE_PORT_OVERRIDE=8080
+RUN sed -i "s|:8080|:${APACHE_PORT_OVERRIDE}|g" /etc/apache2/sites-enabled/iqgeo.apache.conf
+RUN sed -i "s|Listen 8080|Listen ${APACHE_PORT_OVERRIDE}|g" /etc/apache2/ports.conf
 # END CUSTOM SECTION
 
 # # fetch additional python dependencies


### PR DESCRIPTION
This PR allows a developer to override the default apache prort designation via the env variable "APACHE_PORT_OVERRIDE".