### PR TITLE
Add SSL_REQUIRED

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -98,6 +98,7 @@ services:
             KC_PROXY: edge
             IQGEO_DOMAIN: http://${IQGEO_HOST:-localhost:${APP_PORT:-80}}
             IQGEO_CLIENT_SECRET: qpyu1mCm8zvvKTXRnKxwap1A6xMChuY6
+            SSL_REQUIRED: none
         ports:
             - ${KC_HTTPS_PORT:-8443}:${KC_HTTPS_PORT:-8443}
             - ${KEYCLOAK_PORT:-8080}:${KEYCLOAK_PORT:-8080}


### PR DESCRIPTION
With a recent docker update, docker interprets some default values differently. This PR allows the user to manually override the SSL_REQUIRED variable for local development.