### PR TITLE
PLAT-12000: deployments: RQ_REDIS_URL missing in iqgeo service

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -33,7 +33,7 @@ services:
             MYW_DB_USERNAME: ${DB_USERNAME:-iqgeo}
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             SQLALCHEMY_URL: postgresql://${DB_USERNAME:-iqgeo}:${DB_PASSWORD:-password}@${DB_HOST:-postgis}:5432/${MYW_DB_NAME:-myproj}
-            RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379}
+            RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             MYW_TASK_WORKERS: ${MYW_TASK_WORKERS:-1}
             MYW_TASK_QUEUES: ${MYW_TASK_QUEUES:-}
             # START CUSTOM SECTION
@@ -67,6 +67,7 @@ services:
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:redis}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-redis://:password@redis:6379/0}
+            RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             IQGEO_HOST: ${IQGEO_HOST:-localhost}
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KEYCLOAK_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8080}
             MYW_EXT_BASE_URL: http://${IQGEO_HOST:-localhost} # for access from other devices (e.g. iPad running anywhere)


### PR DESCRIPTION
The RQ_REDIS_URL is missing from the iqgeo (app server) image which causes an issue if the databaseRQ_REDIS_URL in the tool container differs from what’s defined in the BEAKER_SESSION_URL

Relates to:
https://iqgeo.atlassian.net/browse/PLAT-12000