### PR TITLE
PLAT-12442: expose MYW_WEB_SESSION_TIMEOUT_HOURS envvar

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -46,6 +46,7 @@ services:
             MYW_DB_PORT: 5432
             MYW_DB_USERNAME: ${DB_USERNAME:-iqgeo}
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
+            MYW_WEB_SESSION_TIMEOUT_HOURS: ${MYW_WEB_SESSION_TIMEOUT_HOURS:-}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:redis}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-redis://:password@redis:6379/0}
             RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -65,6 +65,7 @@ services:
             MYW_DB_PORT: 5432
             MYW_DB_USERNAME: ${DB_USERNAME:-iqgeo}
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
+            MYW_WEB_SESSION_TIMEOUT_HOURS: ${MYW_WEB_SESSION_TIMEOUT_HOURS:-}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:redis}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-redis://:password@redis:6379/0}
             IQGEO_HOST: ${IQGEO_HOST:-localhost}


### PR DESCRIPTION
Exposes the MYW_WEB_SESSION_TIMEOUT_HOURS envvar used here: https://github.com/IQGeo/utils-docker-platform/pull/386