### PR TITLE
Upgrade the default platform version to 7.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Project for customer MyProject",
+    "name": "IQGeo Project Template",
     "dockerComposeFile": "docker-compose.yml",
     "service": "iqgeo",
     "runServices": ["iqgeo", "rq-dashboard"],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "IQGeo Project Template",
+    "name": "Project for customer MyProject",
     "dockerComposeFile": "docker-compose.yml",
     "service": "iqgeo",
     "runServices": ["iqgeo", "rq-dashboard"],

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -10,7 +10,7 @@ FROM ${PRODUCT_REGISTRY}comms/comms:3.3 AS comms
 # END SECTION
 
 
-FROM ${PRODUCT_REGISTRY}platform/platform-devenv-2:7.3
+FROM ${PRODUCT_REGISTRY}platform/platform-devenv-2:7.4
 
 USER root
 

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -8,7 +8,7 @@
     "db_name": "myproj",
     "platform": {
         // The version of the IQGeo platform to use. Options are 7.0, and above
-        "version": "7.3",
+        "version": "7.4",
 
         // Dependency Options: ["memcached", "redis", "ldap", "saml", "oidc"]
         // Please refer to the platform `Install & Configuration Guide` for more information regarding these dependencies.

--- a/deployment/dockerfile.appserver
+++ b/deployment/dockerfile.appserver
@@ -14,7 +14,7 @@ RUN rm -rf ${MODULES}/*/node_modules \
     && rm -rf ${MODULES}/*/native
 
 ############################################## project appserver image
-FROM ${PRODUCT_REGISTRY}platform/platform-appserver:7.3
+FROM ${PRODUCT_REGISTRY}platform/platform-appserver:7.4
 
 USER root
 

--- a/deployment/dockerfile.build
+++ b/deployment/dockerfile.build
@@ -4,7 +4,7 @@ FROM ${PRODUCT_REGISTRY}comms/comms:3.3 AS comms
 # END SECTION
 
 # Create container for building the project
-FROM ${PRODUCT_REGISTRY}platform/platform-build:7.3
+FROM ${PRODUCT_REGISTRY}platform/platform-build:7.4
 
 # START SECTION Copy the modules - if you edit these lines manually note that your change will get lost if you run the IQGeo Project Update tool
 COPY --link custom ${MODULES}/custom

--- a/deployment/dockerfile.tools
+++ b/deployment/dockerfile.tools
@@ -6,7 +6,7 @@ FROM iqgeo-myproj-build AS iqgeo_builder
 
 # END SECTION
 
-FROM ${PRODUCT_REGISTRY}platform/platform-tools:7.3 AS tools_intermediate
+FROM ${PRODUCT_REGISTRY}platform/platform-tools:7.4 AS tools_intermediate
 
 USER root
 


### PR DESCRIPTION
This PR updates the default platform version from 7.3 to 7.4. This branch was tested by changing the platform version to 7.4 running the IQGeo updated vscode feature to update relevant files. Then the running app was inspected to check the app behaved as expected.