### PR TITLE
deployment:  Add shared-data volume

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -33,11 +33,14 @@ services:
             MYW_DB_USERNAME: ${DB_USERNAME:-iqgeo}
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             SQLALCHEMY_URL: postgresql://${DB_USERNAME:-iqgeo}:${DB_PASSWORD:-password}@${DB_HOST:-postgis}:5432/${MYW_DB_NAME:-myproj}
+            SHARED_DIRECTORY: /shared-data
             RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             MYW_TASK_WORKERS: ${MYW_TASK_WORKERS:-1}
             MYW_TASK_QUEUES: ${MYW_TASK_QUEUES:-}
             # START CUSTOM SECTION
             # END CUSTOM SECTION
+        volumes:
+            - shared-data:/shared-data
 
     iqgeo:
         build:
@@ -67,6 +70,7 @@ services:
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:redis}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-redis://:password@redis:6379/0}
+            SHARED_DIRECTORY: /shared-data
             RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             IQGEO_HOST: ${IQGEO_HOST:-localhost}
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KEYCLOAK_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8080}
@@ -76,6 +80,8 @@ services:
             # END CUSTOM SECTION
         ports:
             - ${APPSERVER_PORT:-80}:8080
+        volumes:
+            - shared-data:/shared-data
 
     keycloak:
         container_name: keycloak_${PROJ_PREFIX:-myproj}
@@ -112,3 +118,7 @@ volumes:
         name: ${PROJ_PREFIX:-myproj}_pgdata-example15
         # START CUSTOM SECTION
         # END CUSTOM SECTION
+    shared-data:
+        name: ${PROJ_PREFIX:-myproj}_shared-data
+        # START CUSTOM SECTION
+        # END CUSTOM SECTION  

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -33,7 +33,6 @@ services:
             MYW_DB_USERNAME: ${DB_USERNAME:-iqgeo}
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             SQLALCHEMY_URL: postgresql://${DB_USERNAME:-iqgeo}:${DB_PASSWORD:-password}@${DB_HOST:-postgis}:5432/${MYW_DB_NAME:-myproj}
-            SHARED_DIRECTORY: /shared-data
             RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             MYW_TASK_WORKERS: ${MYW_TASK_WORKERS:-1}
             MYW_TASK_QUEUES: ${MYW_TASK_QUEUES:-}
@@ -70,7 +69,6 @@ services:
             MYW_DB_PASSWORD: ${DB_PASSWORD:-password}
             BEAKER_SESSION_TYPE: ${BEAKER_SESSION_TYPE:-ext:redis}
             BEAKER_SESSION_URL: ${BEAKER_SESSION_URL:-redis://:password@redis:6379/0}
-            SHARED_DIRECTORY: /shared-data
             RQ_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
             IQGEO_HOST: ${IQGEO_HOST:-localhost}
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KEYCLOAK_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8080}

--- a/deployment/dockerfile.appserver
+++ b/deployment/dockerfile.appserver
@@ -37,6 +37,11 @@ COPY --chown=www-data:www-data --from=iqgeo_builder ${MODULES}/comms/ ${MODULES}
 # Copy in generated bundles
 COPY --chown=www-data:www-data --from=iqgeo_builder ${WEBAPPS}/myworldapp/public ${WEBAPPS}/myworldapp/public/
 
+# Give www-data user ownership of the shared directory
+ENV SHARED_DIRECTORY=/shared-data
+RUN mkdir -p ${SHARED_DIRECTORY}
+RUN chown -R www-data:www-data ${SHARED_DIRECTORY}
+
 
 USER www-data
 

--- a/deployment/dockerfile.tools
+++ b/deployment/dockerfile.tools
@@ -28,6 +28,11 @@ COPY --chown=www-data:www-data --from=iqgeo_builder ${WEBAPPS}/myworldapp/dist $
 RUN chown -R www-data:www-data entrypoint.d && \
     chown www-data:www-data entrypoint.d.sh
 
+# Give www-data user ownership of the shared directory
+ENV SHARED_DIRECTORY=/shared-data
+RUN mkdir -p ${SHARED_DIRECTORY}
+RUN chown -R www-data:www-data ${SHARED_DIRECTORY}
+
 USER www-data
 
 # add additional entrypoint scripts (build db, ...)


### PR DESCRIPTION
For features such as upload Data, LRT needs to have shared_data between the appserver and workers.

The changes to the deployment/dockerfile are intended to introduce a name volume to act as this shared-data, and for the SHARED_DIRECTORY to be defined correctly to update configuration such as the upload_cache.

Due to problems with my local docker I haven't been able to test this stands up and performs correctly so I've left this PR in draft; however if you are able to test and verify the functionality, it's here so it can be merged into dev.
 