### PR TITLE
devcontainer: added pgadmin service to list in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "IQGeo Project Template",
     "dockerComposeFile": "docker-compose.yml",
     "service": "iqgeo",
-    "runServices": ["iqgeo", "rq-dashboard"],
+    "runServices": ["iqgeo", "rq-dashboard", "pgadmin"],
     "workspaceFolder": "/opt/iqgeo/platform/WebApps/myworldapp/modules",
     "shutdownAction": "stopCompose",
     "customizations": {


### PR DESCRIPTION
This pull request makes a minor update to the dev container configuration by adding an additional service to the list of services that are started when the container launches.

* Added `pgadmin` to the `runServices` array in `.devcontainer/devcontainer.json`, ensuring the pgAdmin database management tool is available by default in the development environment.