### PR TITLE
dockerfile: removed cryptojwt

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -20,8 +20,6 @@ RUN mkdir -p ${MYWORLD_DATA_HOME}/tests
 
 # END SECTION
 
-RUN pip install cryptojwt
-
 # START SECTION Copy the modules - beware this section is updated by the IQGeo project configuration tool
 COPY --from=comms / ${MODULES}/
 # END SECTION


### PR DESCRIPTION
Relates To: task/PLAT-13186-remove-cryptojwt

This pull request makes a minor change to the `.devcontainer/dockerfile` by removing the installation of the `cryptojwt` Python package. This streamlines the container setup and may reduce unnecessary dependencies.