### PR TITLE
docs: add PostGIS image version guidance to devcontainer READMEs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -50,6 +50,26 @@ The **Visual Studio Code Remote - Containers** extension lets you use a Docker c
 
 Overriding of environment variables in the `docker-compose.yml` can be done via `.env` file in this folder. Copy the `.env.example` file to `.env` and modify the values as described in its comments.
 
+### PostGIS Image Version
+
+The default PostGIS image used in `docker-compose.yml` is:
+
+```yaml
+image: ghcr.io/iqgeo/docker-postgis/postgis:15-3.5
+```
+
+This image is hosted by IQGeo specifically to provide compatibility with Mac ARM (Apple Silicon) laptops. To match your production database version, change the `image:` value under the `postgis:` service in `.devcontainer/docker-compose.yml`. The official PostGIS images are available on Docker Hub and use the same tag format (`<postgres_major_version>-<postgis_version>`):
+
+https://hub.docker.com/r/postgis/postgis
+
+For example, to use PostgreSQL 16 with PostGIS 3.4:
+
+```yaml
+image: postgis/postgis:16-3.4
+```
+
+> **Note:** On Mac ARM, IQGeo publishes a limited set of ARM-compatible images under `ghcr.io/iqgeo/docker-postgis/postgis`, primarily covering versions used in active product development. If the version you need is not available there, the official `postgis/postgis` image from Docker Hub can still be used — Docker will run the `amd64` variant via emulation.
+
 ### Connecting To Containers From Host
 
 The APP_PORT and DB_PORT parameters are used to map Apache and PostgreSQL to ports on your local machine (Docker Port Mapping). This allows you to connect to Apache on http://localhost:APP_PORT and PostgreSQL via a PSQL client.

--- a/.devcontainer/remote_host/README.md
+++ b/.devcontainer/remote_host/README.md
@@ -42,6 +42,24 @@ APP_PORT=8081
 
 Edit the entries to give each developer unique values.
 
+### PostGIS Image Version
+
+The PostGIS image version is defined in `.devcontainer/docker-compose.yml` (which `docker-compose-shared.yml` inherits) and defaults to:
+
+```yaml
+image: ghcr.io/iqgeo/docker-postgis/postgis:15-3.5
+```
+
+The IQGeo-hosted images under `ghcr.io/iqgeo` are provided for Mac ARM (Apple Silicon) compatibility. On a remote Linux server (x86) there is no such constraint, so it is recommended to use the official PostGIS image from Docker Hub and select the tag that matches your production database:
+
+https://hub.docker.com/r/postgis/postgis
+
+For example, to use PostgreSQL 16 with PostGIS 3.4, change the `image:` under the `postgis:` service in `.devcontainer/docker-compose.yml`:
+
+```yaml
+image: postgis/postgis:16-3.4
+```
+
 ### Open Dev Container in VS Code
 
 You can now run the VS Code command "dev containers: Reopen in Container". (This can be done by clicking the blue button on bottom left corner of the window and chosing that command from the list or by pressing Cmd/Ctrl+P and typing in the command)


### PR DESCRIPTION
Adds a "PostGIS Image Version" section to both `.devcontainer/README.md` and `.devcontainer/remote_host/README.md` explaining:

- The default `ghcr.io/iqgeo/docker-postgis/postgis` image is provided by IQGeo for Mac ARM (Apple Silicon) compatibility
- Users/projects can change the image to match their production database version
- Links to the official PostGIS Docker Hub for available tags
- On remote Linux servers (x86), the official `postgis/postgis` image should be used directly
- On Mac ARM, the official image can still be used via emulation if the required version is not in the IQGeo registry