### PR TITLE
DX-40: docker-compose: added openbao and centrifugo services - disabled by default.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -59,6 +59,11 @@ services:
             APACHE_ERROR_LOG: /var/log/apache2/error.log
             ROPC_ENABLE: ${ROPC_ENABLE:-true}
             MYW_DB_UPGRADE: ${MYW_DB_UPGRADE:-YES} # Set to YES to run DB upgrade scripts on container start
+            CENTRIFUGO_APACHE_PROXY: 'YES'
+            CENTRIFUGO_HTTP_API_KEY: ${CENTRIFUGO_HTTP_API_KEY:-6b213c49-1baf-43ec-9ffd-28a69edf5514}
+            CENTRIFUGO_API_URL: ${CENTRIFUGO_API_URL:-http://centrifugo:8000/api}
+            OPENBAO_ADDRESS: http://openbao:${OPENBAO_PORT:-8200}
+            OPENBAO_TOKEN: ${OPENBAO_TOKEN:-not_for_production_use}
             # START CUSTOM SECTION
             # END CUSTOM SECTION
         ports:
@@ -142,6 +147,42 @@ services:
             RQ_DASHBOARD_REDIS_URL: ${REDIS_URL:-redis://:password@redis:6379/1}
         depends_on:
             - redis
+
+    openbao:
+        profiles: ['disabled']
+        image: openbao/openbao:latest
+        restart: always
+        container_name: openbao_${PROJ_PREFIX:-myproj}
+        ports:
+            - ${OPENBAO_PORT:-8200}:${OPENBAO_PORT:-8200}
+        environment:
+            OPENBAO_DEV_ROOT_TOKEN_ID: ${OPENBAO_TOKEN:-not_for_production_use}
+            OPENBAO_DEV_LISTEN_ADDRESS: 0.0.0.0:${OPENBAO_PORT:-8200}
+        cap_add:
+            - IPC_LOCK
+        command: server -dev -dev-root-token-id="${OPENBAO_TOKEN:-not_for_production_use}"
+        
+    centrifugo:
+        profiles: ['disabled']
+        image: centrifugo/centrifugo:v6
+        container_name: centrifugo_${PROJ_PREFIX:-myproj}
+        restart: unless-stopped
+        ports:
+            - ${CENTRIFUGO_PORT:-8000}:8000
+        command: centrifugo
+        environment:
+            CENTRIFUGO_ADMIN_PASSWORD: ${CENTRIFUGO_ADMIN_PASSWORD:-not_for_production_use}
+            CENTRIFUGO_HTTP_API_KEY: ${CENTRIFUGO_HTTP_API_KEY:-6b213c49-1baf-43ec-9ffd-28a69edf5514}
+            CENTRIFUGO_ADMIN_SECRET: ${CENTRIFUGO_ADMIN_SECRET:-VJaNwhRxcO6T26Dk5YD}
+            CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX: ${CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX:-/modules/notification_manager/websocket}
+            CENTRIFUGO_CLIENT_ALLOWED_ORIGINS: ${CENTRIFUGO_CLIENT_ALLOWED_ORIGINS:-*}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED:-true}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT:-http://iqgeo:8080/modules/notification_manager/api/v1/authorize}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS:-Cookie X-CSRF-Token}
+            CENTRIFUGO_SWAGGER_ENABLED: ${CENTRIFUGO_SWAGGER_ENABLED:-true}
+            CENTRIFUGO_ADMIN_ENABLED: ${CENTRIFUGO_ADMIN_ENABLED:-true}
+            CENTRIFUGO_DEBUG_ENABLED: ${CENTRIFUGO_DEBUG_ENABLED:-true}
+            CENTRIFUGO_LOG_LEVEL: ${CENTRIFUGO_LOG_LEVEL:-trace}
     # START CUSTOM SECTION
     # END CUSTOM SECTION
 

--- a/.devcontainer/remote_host/docker-compose-shared.yml
+++ b/.devcontainer/remote_host/docker-compose-shared.yml
@@ -48,6 +48,23 @@ services:
         networks:
             - iqgeo-network
 
+
+    openbao:
+        extends:
+            file: ../docker-compose.yml
+            service: openbao
+        container_name: openbao
+        networks:
+            - iqgeo-network
+
+    centrifugo:
+        extends:
+            file: ../docker-compose.yml
+            service: centrifugo
+        container_name: centrifugo
+        networks:
+            - iqgeo-network
+
     # START CUSTOM SECTION
     # END CUSTOM SECTION
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -65,6 +65,11 @@ services:
             KEYCLOAK_URL: ${KC_PROTOCOL:-http://}${KEYCLOAK_HOST:-keycloak.local}:${KEYCLOAK_PORT:-8080}
             MYW_EXT_BASE_URL: http://${IQGEO_HOST:-localhost} # for access from other devices (e.g. iPad running anywhere)
             MYW_DB_UPGRADE: ${MYW_DB_UPGRADE:-NO} # Default to NO to prevent accidental DB upgrade on appserver start
+            CENTRIFUGO_APACHE_PROXY: 'YES'
+            CENTRIFUGO_HTTP_API_KEY: ${CENTRIFUGO_HTTP_API_KEY:-6b213c49-1baf-43ec-9ffd-28a69edf5514}
+            CENTRIFUGO_API_URL: ${CENTRIFUGO_API_URL:-http://centrifugo:8000/api}
+            OPENBAO_ADDRESS: http://openbao:${OPENBAO_PORT:-8200}
+            OPENBAO_TOKEN: ${OPENBAO_TOKEN:-not_for_production_use}
             # START CUSTOM SECTION
             # END CUSTOM SECTION
         ports:
@@ -98,6 +103,42 @@ services:
         image: redis:latest
         restart: always
         command: redis-server --requirepass ${REDIS_PASSWORD:-password}
+
+    openbao:
+        profiles: ['disabled']
+        image: openbao/openbao:latest
+        restart: always
+        container_name: openbao_${PROJ_PREFIX:-myproj}
+        ports:
+            - ${OPENBAO_PORT:-8200}:${OPENBAO_PORT:-8200}
+        environment:
+            OPENBAO_DEV_ROOT_TOKEN_ID: ${OPENBAO_TOKEN:-not_for_production_use}
+            OPENBAO_DEV_LISTEN_ADDRESS: 0.0.0.0:${OPENBAO_PORT:-8200}
+        cap_add:
+            - IPC_LOCK
+        command: server -dev -dev-root-token-id="${OPENBAO_TOKEN:-not_for_production_use}"
+        
+    centrifugo:
+        profiles: ['disabled']
+        image: centrifugo/centrifugo:v6
+        container_name: centrifugo_${PROJ_PREFIX:-myproj}
+        restart: unless-stopped
+        ports:
+            - ${CENTRIFUGO_PORT:-8000}:8000
+        command: centrifugo
+        environment:
+            CENTRIFUGO_ADMIN_PASSWORD: ${CENTRIFUGO_ADMIN_PASSWORD:-not_for_production_use}
+            CENTRIFUGO_HTTP_API_KEY: ${CENTRIFUGO_HTTP_API_KEY:-6b213c49-1baf-43ec-9ffd-28a69edf5514}
+            CENTRIFUGO_ADMIN_SECRET: ${CENTRIFUGO_ADMIN_SECRET:-VJaNwhRxcO6T26Dk5YD}
+            CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX: ${CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX:-/modules/notification_manager/websocket}
+            CENTRIFUGO_CLIENT_ALLOWED_ORIGINS: ${CENTRIFUGO_CLIENT_ALLOWED_ORIGINS:-*}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED:-true}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT:-http://iqgeo:8080/modules/notification_manager/api/v1/authorize}
+            CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS:-Cookie X-CSRF-Token}
+            CENTRIFUGO_SWAGGER_ENABLED: ${CENTRIFUGO_SWAGGER_ENABLED:-true}
+            CENTRIFUGO_ADMIN_ENABLED: ${CENTRIFUGO_ADMIN_ENABLED:-true}
+            CENTRIFUGO_DEBUG_ENABLED: ${CENTRIFUGO_DEBUG_ENABLED:-true}
+            CENTRIFUGO_LOG_LEVEL: ${CENTRIFUGO_LOG_LEVEL:-trace}
     # START CUSTOM SECTION
     # END CUSTOM SECTION
 


### PR DESCRIPTION
This pull request adds support for two new services, `openbao` and `centrifugo`, to the development and deployment Docker Compose configurations. It also introduces related environment variables to enable integration with these services. The changes are grouped as follows:

Relates To: https://iqgeo.atlassian.net/browse/DX-40

**Service Integration:**

* Added `openbao` and `centrifugo` service definitions to `.devcontainer/docker-compose.yml` and `deployment/docker-compose.yml`, with default profiles set to `'disabled'`. These services are configured with appropriate ports, environment variables, and startup commands for local development and deployment. [[1]](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1R150-R185) [[2]](diffhunk://#diff-2b55e4c5b746598b1dd89b62c657486786aaf3faca0d6c95c7225f619d47e164R106-R141)
* Extended the shared remote host Docker Compose file `.devcontainer/remote_host/docker-compose-shared.yml` to include `openbao` and `centrifugo` by referencing their definitions from the main Compose file, ensuring network connectivity. 
* The services are enabled if notification_manager or orchestration manager are added to the iqgeorc.jsonc file and the project update script is run via the vscode extension. (beta can be installed manually from here https://github.com/IQGeo/utils-vscode/releases/tag/v1.0.34-beta.1)

**Environment Variable Configuration:**

* Introduced new environment variables for `openbao` (`OPENBAO_ADDRESS`, `OPENBAO_TOKEN`) and `centrifugo` (`CENTRIFUGO_APACHE_PROXY`, `CENTRIFUGO_HTTP_API_KEY`, `CENTRIFUGO_API_URL`) in the main application service definitions within `.devcontainer/docker-compose.yml` and `deployment/docker-compose.yml`. This enables the application to interact with these services when they are enabled. [[1]](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1R62-R66) [[2]](diffhunk://#diff-2b55e4c5b746598b1dd89b62c657486786aaf3faca0d6c95c7225f619d47e164R68-R72)


This will be paired with these PRs
https://github.com/IQGeo/utils-docker-platform/pull/442
https://github.com/IQGeo/utils-vscode/pull/43

