### PR TITLE
DX-77: Update default platform version to 7.5

### DIFF
--- a/.github/workflows/build-deployment-images.yml
+++ b/.github/workflows/build-deployment-images.yml
@@ -5,10 +5,10 @@ on:
   workflow_dispatch:
     inputs:
       platform_version:
-        description: 'Platform version for base image (e.g., 7.4)'
+        description: 'Platform version for base image (e.g., 7.5)'
         required: false
         type: string
-        default: '7.4'
+        default: '7.5'
       custom_version:
         description: 'Override auto-generated CalVer (YYYY.MM.DD.BUILD format)'
         required: false
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  PLATFORM_VERSION: ${{ github.event.inputs.platform_version || '7.4' }}
+  PLATFORM_VERSION: ${{ github.event.inputs.platform_version || '7.5' }}
   PRODUCT_REGISTRY: harbor.delivery.iqgeo.cloud
   PRODUCT_REPOSITORY_PREFIX: releases_
   PROJECT_REGISTRY: harbor.delivery.iqgeo.cloud

--- a/.iqgeorc.jsonc
+++ b/.iqgeorc.jsonc
@@ -8,7 +8,7 @@
     "db_name": "myproj",
     "platform": {
         // The version of the IQGeo platform to use. Options are 7.0, and above
-        "version": "7.4",
+        "version": "7.5",
 
         // Dependency Options: ["memcached", "redis", "ldap", "saml", "oidc"]
         // Please refer to the platform `Install & Configuration Guide` for more information regarding these dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - DX-37: devcontainer: add copilot cli with instructions on how to configure it.
 - DX-74: fix PRODUCT_REPOSITORY_PREFIX overwriting PRODUCT_REGISTRY in BUILD_ARGS
+- DX-77: iqgeorc.jsonc updated default to platform 7.5
 
 #### v1.2.0 (05/28/2026)
 


### PR DESCRIPTION
## Summary
Updates the default IQGeo platform version from `7.4` to `7.5`.

## Changes
- `.iqgeorc.jsonc`: `platform.version` → `7.5`
- `.github/workflows/build-deployment-images.yml`: `platform_version` input default, description example, and `PLATFORM_VERSION` env fallback → `7.5`
- `CHANGELOG.md`: added DX-77 entry

Jira: DX-77